### PR TITLE
Bootstrap FITDJ SwiftUI app scaffold

### DIFF
--- a/App/DI/AppCoordinator.swift
+++ b/App/DI/AppCoordinator.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import Combine
+
+final class AppCoordinator: ObservableObject {
+    private let container: DependencyContainer
+    @Published private var route: AppRoute = .launch
+
+    init(container: DependencyContainer = DependencyContainer()) {
+        self.container = container
+        Task { await bootstrap() }
+    }
+
+    @ViewBuilder
+    func rootView() -> some View {
+        switch route {
+        case .launch:
+            LaunchView()
+                .task { await bootstrap() }
+        case .onboarding:
+            OnboardingCoordinatorView(container: container) {
+                await self.completeOnboarding()
+            }
+        case .home:
+            HomeView(container: container)
+        }
+    }
+
+    @MainActor
+    private func bootstrap() async {
+        let account = try? container.authService.currentUser()
+        route = account != nil ? .home : .onboarding
+    }
+
+    @MainActor
+    private func completeOnboarding() async {
+        route = .home
+    }
+}
+
+enum AppRoute {
+    case launch
+    case onboarding
+    case home
+}

--- a/App/DI/DependencyContainer.swift
+++ b/App/DI/DependencyContainer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+final class DependencyContainer {
+    let workoutRepository: WorkoutRepository
+    let playbackController: PlaybackController
+    let voiceService: VoiceService
+    let musicService: MusicService
+    let authService: AuthService
+    let paymentsService: PaymentsService
+    let analyticsService: AnalyticsService
+
+    init(
+        workoutRepository: WorkoutRepository = WorkoutRepositoryFirestore(),
+        playbackController: PlaybackController = DemoPlaybackController(),
+        voiceService: VoiceService = ElevenLabsVoiceServiceStub(),
+        musicService: MusicService = SpotifyMusicServiceStub(),
+        authService: AuthService = AuthServiceStub(),
+        paymentsService: PaymentsService = PaymentsServiceStub(),
+        analyticsService: AnalyticsService = AnalyticsServiceStub()
+    ) {
+        self.workoutRepository = workoutRepository
+        self.playbackController = playbackController
+        self.voiceService = voiceService
+        self.musicService = musicService
+        self.authService = authService
+        self.paymentsService = paymentsService
+        self.analyticsService = analyticsService
+    }
+}

--- a/App/Extensions/Color+Brand.swift
+++ b/App/Extensions/Color+Brand.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+extension Color {
+    static let fitdjBackground = Color("Background", bundle: .main)
+    static let fitdjAccent = Color("Accent", bundle: .main)
+}

--- a/App/FITDJApp.swift
+++ b/App/FITDJApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct FITDJApp: App {
+    @StateObject private var appCoordinator = AppCoordinator()
+
+    var body: some Scene {
+        WindowGroup {
+            appCoordinator.rootView()
+                .environmentObject(appCoordinator)
+        }
+    }
+}

--- a/App/Resources/Audio/tts_pregenerated/README.md
+++ b/App/Resources/Audio/tts_pregenerated/README.md
@@ -1,0 +1,3 @@
+# Pre-generated Voice Cues
+
+Place common ElevenLabs cues here as MP3 files. These ship with the app bundle for instant playback.

--- a/App/Resources/Colors.xcassets/Accent.colorset/Contents.json
+++ b/App/Resources/Colors.xcassets/Accent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.373",
+          "green" : "0.353",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Colors.xcassets/Background.colorset/Contents.json
+++ b/App/Resources/Colors.xcassets/Background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.318",
+          "green" : "0.129",
+          "red" : "0.102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Colors.xcassets/Contents.json
+++ b/App/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/VideoLoops/README.md
+++ b/App/Resources/VideoLoops/README.md
@@ -1,0 +1,3 @@
+# Video Loops
+
+Store 10–15 second HD MP4 loops for each exercise here. They should be optimized for seamless playback.

--- a/Core/Analytics/AnalyticsServiceStub.swift
+++ b/Core/Analytics/AnalyticsServiceStub.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+final class AnalyticsServiceStub: AnalyticsService {
+    func track(_ event: AnalyticsEvent) {
+        print("Analytics event: \(event.name)")
+    }
+}

--- a/Core/Audio/AudioEngineController.swift
+++ b/Core/Audio/AudioEngineController.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AVFoundation
+import Combine
+
+final class AudioEngineController: ObservableObject {
+    private let engine = AVAudioEngine()
+    private let voicePlayer = AVAudioPlayerNode()
+    private let voiceMixer = AVAudioMixerNode()
+    @Published var coachGain: Float = 0
+
+    init() {
+        engine.attach(voicePlayer)
+        engine.attach(voiceMixer)
+        engine.connect(voicePlayer, to: voiceMixer, format: nil)
+        engine.connect(voiceMixer, to: engine.mainMixerNode, format: nil)
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.allowBluetoothA2DP])
+        try? engine.start()
+    }
+
+    func playVoice(_ fileURL: URL, onStart: @escaping () -> Void, onEnd: @escaping () -> Void) {
+        do {
+            let file = try AVAudioFile(forReading: fileURL)
+            voicePlayer.scheduleFile(file, at: nil) { onEnd() }
+            onStart()
+            voicePlayer.play()
+        } catch {
+            onStart()
+            onEnd()
+        }
+    }
+}

--- a/Core/Audio/CueScheduler.swift
+++ b/Core/Audio/CueScheduler.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class CueScheduler {
+    private let timeline: TimelineScheduler
+    private let voice: VoiceService
+    private let duck: DuckingCoordinator
+
+    init(timeline: TimelineScheduler, voice: VoiceService, duck: DuckingCoordinator) {
+        self.timeline = timeline
+        self.voice = voice
+        self.duck = duck
+    }
+
+    func schedule(cue: VoiceCue, at offset: TimeInterval) {
+        Task {
+            await timeline.schedule(atOffset: offset) { [weak self] in
+                guard let self else { return }
+                Task {
+                    let deadline = Date().addingTimeInterval(0.3)
+                    self.duck.beginDuck(attack: 0.3, gainDB: -12)
+                    await self.voice.speak(cue, deadline: deadline)
+                    self.duck.endDuck(release: 0.3)
+                }
+            }
+        }
+    }
+}

--- a/Core/Audio/DemoPlaybackController.swift
+++ b/Core/Audio/DemoPlaybackController.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+final class DemoPlaybackController: PlaybackController {
+    private var scheduler = TimelineScheduler()
+
+    func start(_ session: WorkoutSession) async throws {
+        scheduler.startNow()
+        // TODO: Bind to real playback engine
+    }
+
+    func pause() {}
+
+    func resume() {}
+
+    func stop() {}
+}

--- a/Core/Audio/DuckingCoordinator.swift
+++ b/Core/Audio/DuckingCoordinator.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol DuckingCoordinator {
+    func beginDuck(attack: TimeInterval, gainDB: Float)
+    func endDuck(release: TimeInterval)
+}
+
+final class SpotifyDuckingCoordinator: DuckingCoordinator {
+    private let musicService: MusicService
+
+    init(musicService: MusicService) {
+        self.musicService = musicService
+    }
+
+    func beginDuck(attack: TimeInterval, gainDB: Float) {
+        musicService.setMusicDuck(level: gainDB, attack: attack, release: 0)
+    }
+
+    func endDuck(release: TimeInterval) {
+        musicService.setMusicDuck(level: 0, attack: 0, release: release)
+    }
+}

--- a/Core/Auth/AuthServiceStub.swift
+++ b/Core/Auth/AuthServiceStub.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class AuthServiceStub: AuthService {
+    private var account: UserAccount?
+
+    func signInWithApple() async throws -> UserAccount {
+        let user = UserAccount(id: UUID().uuidString, name: "Demo Athlete")
+        account = user
+        return user
+    }
+
+    func currentUser() throws -> UserAccount? {
+        account
+    }
+}

--- a/Core/Data/Models.swift
+++ b/Core/Data/Models.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SwiftUI
+
+enum WorkoutLevel: String, Codable, CaseIterable, Identifiable {
+    case beginner, intermediate, advanced
+    var id: String { rawValue }
+}
+
+enum Equipment: String, Codable, CaseIterable, Identifiable {
+    case bodyweight, dumbbells, kettlebell, bands, bench
+    var id: String { rawValue }
+}
+
+struct WorkoutPhase: Codable, Identifiable {
+    struct Block: Codable, Identifiable {
+        let id = UUID()
+        let branch: String?
+        let exercise: String
+        let duration: Int
+        let rest: Int?
+        let video: String?
+        let cues: [String]?
+    }
+
+    let id = UUID()
+    let name: String
+    let blocks: [Block]
+}
+
+struct Workout: Codable, Identifiable {
+    struct MusicBinding: Codable {
+        let playlistAdminId: String
+        let bpmTarget: [Double]
+        let energy: [Double]
+    }
+
+    let id: String
+    let title: String
+    let duration: Int
+    let level: WorkoutLevel
+    let equipment: [Equipment]
+    let phases: [WorkoutPhase]
+    let music: MusicBinding
+}
+
+struct Exercise: Codable, Identifiable {
+    let id: String
+    let name: String
+    let muscles: [String]
+    let equipment: [Equipment]
+    let difficulty: WorkoutLevel
+    let video: String
+}
+
+struct VoiceCue: Codable, Hashable, Identifiable {
+    enum Priority: Int, Codable {
+        case encouragement = 1
+        case countdown = 2
+        case safety = 3
+    }
+
+    let id: String
+    let text: String
+    let type: Priority
+    let locale: String
+    let prebundledAsset: String?
+}
+
+struct PlaylistBinding {
+    let spotifyURI: String
+    let defaultCriteria: TrackCriteria
+}
+
+struct TrackCriteria {
+    let bpm: ClosedRange<Double>
+    let energy: ClosedRange<Double>
+}
+
+struct WorkoutSession {
+    let workout: Workout
+    let startDate: Date
+    let intensity: TrackCriteria
+}
+
+struct UserAccount: Identifiable {
+    let id: String
+    let name: String
+}
+
+struct AnalyticsEvent {
+    let name: String
+    let metadata: [String: String]
+}

--- a/Core/Data/WorkoutRepositoryFirestore.swift
+++ b/Core/Data/WorkoutRepositoryFirestore.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class WorkoutRepositoryFirestore: WorkoutRepository {
+    private let loader: SeedDataLoader
+
+    init(loader: SeedDataLoader = SeedDataLoader()) {
+        self.loader = loader
+    }
+
+    func fetchFeatured() async throws -> [Workout] {
+        return try await loader.loadWorkouts()
+    }
+
+    func get(id: String) async throws -> Workout {
+        let workouts = try await loader.loadWorkouts()
+        guard let workout = workouts.first(where: { $0.id == id }) else {
+            throw NSError(domain: "fitdj", code: 404)
+        }
+        return workout
+    }
+}
+
+final class SeedDataLoader {
+    func loadWorkouts() async throws -> [Workout] {
+        let url = Bundle.main.url(forResource: "workouts", withExtension: "json", subdirectory: "Seeds")
+        let data = try Data(contentsOf: url ?? URL(fileURLWithPath: "Seeds/workouts.json"))
+        let decoder = JSONDecoder()
+        return try decoder.decode([Workout].self, from: data)
+    }
+}

--- a/Core/ElevenLabs/ElevenLabsVoiceServiceStub.swift
+++ b/Core/ElevenLabs/ElevenLabsVoiceServiceStub.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+#if DEBUG
+final class ElevenLabsVoiceServiceStub: VoiceService {
+    func preload(cues: [VoiceCue]) async {}
+    func speak(_ cue: VoiceCue, deadline: Date?) async {
+        // TODO: Integrate ElevenLabs streaming
+    }
+}
+#else
+final class ElevenLabsVoiceServiceStub: VoiceService {
+    func preload(cues: [VoiceCue]) async {}
+    func speak(_ cue: VoiceCue, deadline: Date?) async {}
+}
+#endif

--- a/Core/Network/NetworkClientStub.swift
+++ b/Core/Network/NetworkClientStub.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class NetworkClientStub {
+    func get(_ url: URL) async throws -> Data {
+        // TODO: Replace with real network stack
+        return Data()
+    }
+}

--- a/Core/Payments/PaymentsServiceStub.swift
+++ b/Core/Payments/PaymentsServiceStub.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class PaymentsServiceStub: PaymentsService {
+    private let entitlementContinuation: AsyncStream<Bool>.Continuation
+    let subscriptionEntitlements: AsyncStream<Bool>
+
+    init() {
+        var continuation: AsyncStream<Bool>.Continuation!
+        self.subscriptionEntitlements = AsyncStream { cont in
+            continuation = cont
+        }
+        self.entitlementContinuation = continuation
+        entitlementContinuation.yield(true)
+    }
+
+    func products() async throws -> [Product] {
+        return [
+            Product(id: "fitdj.monthly", title: "FITDJ Monthly", price: "$14.99", freeTrialDays: 7),
+            Product(id: "fitdj.annual", title: "FITDJ Annual", price: "$99.00", freeTrialDays: 7)
+        ]
+    }
+
+    func purchase(_ id: String) async throws {
+        entitlementContinuation.yield(true)
+    }
+}

--- a/Core/Spotify/SpotifyMusicServiceStub.swift
+++ b/Core/Spotify/SpotifyMusicServiceStub.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class SpotifyMusicServiceStub: MusicService {
+    private var authorized = false
+
+    func authorize() async throws {
+        authorized = true
+    }
+
+    func startPlaylist(_ binding: PlaylistBinding) async throws {
+        guard authorized else { throw NSError(domain: "fitdj", code: 401) }
+        // TODO: Bind to Spotify SDK
+    }
+
+    func setMusicDuck(level: Float, attack: TimeInterval, release: TimeInterval) {
+        // TODO: send duck to Spotify SDK
+    }
+
+    func nextTrack(matching: TrackCriteria) async {
+        // TODO: request next track based on criteria
+    }
+}

--- a/Core/Utilities/Configuration.swift
+++ b/Core/Utilities/Configuration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RemoteConfiguration {
+    let elevenLabsKeyEndpoint: URL
+    let spotifyTokenEndpoint: URL
+    let firestoreProjectId: String
+
+    static let stub = RemoteConfiguration(
+        elevenLabsKeyEndpoint: URL(string: "https://api.example.com/fitdj/tts-token")!,
+        spotifyTokenEndpoint: URL(string: "https://api.example.com/fitdj/spotify-token")!,
+        firestoreProjectId: "fitdj-demo"
+    )
+}

--- a/Core/Utilities/Protocols.swift
+++ b/Core/Utilities/Protocols.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+protocol WorkoutRepository {
+    func fetchFeatured() async throws -> [Workout]
+    func get(id: String) async throws -> Workout
+}
+
+protocol PlaybackController {
+    func start(_ session: WorkoutSession) async throws
+    func pause()
+    func resume()
+    func stop()
+}
+
+protocol VoiceService {
+    func preload(cues: [VoiceCue]) async
+    func speak(_ cue: VoiceCue, deadline: Date?) async
+}
+
+protocol MusicService {
+    func authorize() async throws
+    func startPlaylist(_ binding: PlaylistBinding) async throws
+    func setMusicDuck(level: Float, attack: TimeInterval, release: TimeInterval)
+    func nextTrack(matching: TrackCriteria) async
+}
+
+protocol AuthService {
+    func signInWithApple() async throws -> UserAccount
+    func currentUser() throws -> UserAccount?
+}
+
+protocol PaymentsService {
+    func products() async throws -> [Product]
+    func purchase(_ id: String) async throws
+    var subscriptionEntitlements: AsyncStream<Bool> { get }
+}
+
+protocol AnalyticsService {
+    func track(_ event: AnalyticsEvent)
+}
+
+struct Product: Identifiable {
+    let id: String
+    let title: String
+    let price: String
+    let freeTrialDays: Int
+}

--- a/Core/Utilities/TimelineScheduler.swift
+++ b/Core/Utilities/TimelineScheduler.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+actor TimelineScheduler {
+    private var start: DispatchTime?
+
+    func startNow() {
+        start = .now()
+    }
+
+    func now() -> TimeInterval {
+        guard let s = start else { return 0 }
+        let diff = DispatchTime.now().uptimeNanoseconds - s.uptimeNanoseconds
+        return TimeInterval(diff) / 1_000_000_000
+    }
+
+    func schedule(atOffset seconds: TimeInterval, _ action: @escaping () -> Void) async {
+        let deadline = DispatchTime.now() + seconds
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            action()
+        }
+        Task {
+            try? await Task.sleep(until: deadline, clock: .continuous)
+        }
+    }
+}

--- a/Features/Library/LibraryView.swift
+++ b/Features/Library/LibraryView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct LibraryView: View {
+    let workouts: [Workout]
+
+    var body: some View {
+        List(workouts) { workout in
+            Text(workout.title)
+                .foregroundColor(.white)
+        }
+        .listStyle(.plain)
+        .background(Color.black)
+        .navigationTitle("Library")
+    }
+}

--- a/Features/Onboarding/LaunchView.swift
+++ b/Features/Onboarding/LaunchView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct LaunchView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Preparing FITDJ…")
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Onboarding/OnboardingCoordinatorView.swift
+++ b/Features/Onboarding/OnboardingCoordinatorView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct OnboardingCoordinatorView: View {
+    let container: DependencyContainer
+    let completion: () async -> Void
+    @State private var step: Int = 0
+    @State private var goal: String = "Strength"
+    @State private var equipment: Set<Equipment> = []
+    @State private var musicPreference: Double = 0.5
+
+    var body: some View {
+        VStack {
+            TabView(selection: $step) {
+                GoalStep(goal: $goal)
+                    .tag(0)
+                EquipmentStep(selection: $equipment)
+                    .tag(1)
+                MusicStep(level: $musicPreference)
+                    .tag(2)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .background(Color.fitdjBackground)
+
+            Button(action: next) {
+                Text(step == 2 ? "Continue" : "Next")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.fitdjAccent)
+                    .foregroundColor(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .padding()
+        }
+        .background(Color.black.ignoresSafeArea())
+        .animation(.easeInOut, value: step)
+        .task {
+            await container.musicService.authorize()
+        }
+    }
+
+    private func next() {
+        if step < 2 {
+            step += 1
+        } else {
+            Task { await completion() }
+        }
+    }
+}
+
+private struct GoalStep: View {
+    @Binding var goal: String
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("What brings you to FITDJ?")
+                .font(.title2.bold())
+            Picker("Goal", selection: $goal) {
+                Text("Strength").tag("Strength")
+                Text("Endurance").tag("Endurance")
+                Text("Mobility").tag("Mobility")
+            }
+            .pickerStyle(.segmented)
+        }
+        .padding()
+    }
+}
+
+private struct EquipmentStep: View {
+    @Binding var selection: Set<Equipment>
+    let options: [Equipment] = Equipment.allCases
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("What equipment do you have?")
+                .font(.title2.bold())
+            ForEach(options) { item in
+                Toggle(item.rawValue.capitalized, isOn: Binding(
+                    get: { selection.contains(item) },
+                    set: { isOn in
+                        if isOn { selection.insert(item) } else { selection.remove(item) }
+                    }
+                ))
+                .toggleStyle(.switch)
+            }
+        }
+        .padding()
+    }
+}
+
+private struct MusicStep: View {
+    @Binding var level: Double
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Text("Coach or Music?")
+                .font(.title2.bold())
+            Slider(value: $level, in: 0...1)
+            Text("Balance: \(Int(level * 100))% coach")
+        }
+        .padding()
+    }
+}

--- a/Features/Paywall/PaywallView.swift
+++ b/Features/Paywall/PaywallView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PaywallView: View {
+    let products: [Product]
+    let subscribe: (Product) -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Unlock FITDJ")
+                .font(.largeTitle.bold())
+            Text("Unlimited strength training with dynamic coaching and Spotify integration.")
+                .multilineTextAlignment(.center)
+            ForEach(products) { product in
+                Button(action: { subscribe(product) }) {
+                    VStack(alignment: .leading) {
+                        Text(product.title)
+                            .font(.headline)
+                        Text("\(product.price) · \(product.freeTrialDays)-day free trial")
+                            .font(.subheadline)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.fitdjAccent)
+                    .foregroundColor(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }
+            Text("$14.99/month or $99/year after free trial. Cancel anytime.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Player/WorkoutPlayerView.swift
+++ b/Features/Player/WorkoutPlayerView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct WorkoutPlayerView: View {
+    let workout: Workout
+    let container: DependencyContainer
+    @State private var timeRemaining: Int = 0
+    @State private var isPaused = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(workout.title)
+                .font(.title.bold())
+            Text("Time Remaining: \(timeRemaining)s")
+                .font(.largeTitle.monospacedDigit())
+            Slider(value: .constant(0.5))
+            HStack(spacing: 16) {
+                Button(isPaused ? "Resume" : "Pause") { togglePause() }
+                Button("Skip") {}
+                Button("Easier") {}
+                Button("Harder") {}
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.fitdjAccent)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+        .onAppear {
+            timeRemaining = workout.duration * 60
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+
+    private func togglePause() {
+        isPaused.toggle()
+    }
+}

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct SettingsView: View {
+    let container: DependencyContainer
+    @State private var captionsEnabled = true
+    @State private var products: [Product] = []
+
+    var body: some View {
+        Form {
+            Section("Audio") {
+                Toggle("Captions", isOn: $captionsEnabled)
+                Button("Connect Spotify") {
+                    Task { try? await container.musicService.authorize() }
+                }
+            }
+            Section("Account") {
+                Button("Sign in with Apple") {
+                    Task { _ = try? await container.authService.signInWithApple() }
+                }
+            }
+            Section("Subscription") {
+                if products.isEmpty {
+                    Text("Loading products…")
+                } else {
+                    ForEach(products) { product in
+                        Button("Subscribe to \(product.title) – \(product.price)") {
+                            Task { try? await container.paymentsService.purchase(product.id) }
+                        }
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.black)
+        .foregroundColor(.white)
+        .navigationTitle("Settings")
+        .tint(Color.fitdjAccent)
+        .task { await loadProducts() }
+    }
+
+    private func loadProducts() async {
+        products = (try? await container.paymentsService.products()) ?? []
+    }
+}

--- a/Features/Workouts/CompletionView.swift
+++ b/Features/Workouts/CompletionView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CompletionView: View {
+    let workout: Workout
+    let duration: TimeInterval
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Workout Complete!")
+                .font(.largeTitle.bold())
+            Text("You crushed \(workout.title) in \(Int(duration / 60)) minutes.")
+            Button("Share") {}
+                .buttonStyle(.borderedProminent)
+                .tint(Color.fitdjAccent)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Workouts/HomeView.swift
+++ b/Features/Workouts/HomeView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct HomeView: View {
+    let container: DependencyContainer
+    @State private var workouts: [Workout] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    List(workouts) { workout in
+                        NavigationLink(destination: WorkoutDetailView(workout: workout, container: container)) {
+                            WorkoutRow(workout: workout)
+                        }
+                        .listRowBackground(Color.black)
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Featured")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: SettingsView(container: container)) {
+                        Image(systemName: "gear")
+                    }
+                }
+            }
+        }
+        .accentColor(Color.fitdjAccent)
+        .task { await loadWorkouts() }
+    }
+
+    private func loadWorkouts() async {
+        do {
+            workouts = try await container.workoutRepository.fetchFeatured()
+        } catch {
+            workouts = []
+        }
+        isLoading = false
+    }
+}
+
+private struct WorkoutRow: View {
+    let workout: Workout
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(workout.title)
+                .font(.headline)
+                .foregroundColor(.white)
+            Text("\(workout.duration) min · \(workout.level.rawValue.capitalized)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/Features/Workouts/WorkoutDetailView.swift
+++ b/Features/Workouts/WorkoutDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct WorkoutDetailView: View {
+    let workout: Workout
+    let container: DependencyContainer
+    @State private var showingPlayer = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(workout.title)
+                    .font(.largeTitle.bold())
+                Text("Duration: \(workout.duration) minutes")
+                Text("Equipment: \(workout.equipment.map { $0.rawValue.capitalized }.joined(separator: ", "))")
+                Text("Level: \(workout.level.rawValue.capitalized)")
+                Divider()
+                ForEach(workout.phases) { phase in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(phase.name)
+                            .font(.headline)
+                        ForEach(phase.blocks) { block in
+                            Text(block.exercise.replacingOccurrences(of: "_", with: " "))
+                                .font(.subheadline)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                }
+            }
+            .padding()
+            .foregroundColor(.white)
+        }
+        .background(Color.black.ignoresSafeArea())
+        .toolbar {
+            Button("Start") { showingPlayer = true }
+        }
+        .sheet(isPresented: $showingPlayer) {
+            WorkoutPlayerView(workout: workout, container: container)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# FITDJ iOS App Skeleton
+
+This repository contains the SwiftUI-based FITDJ application scaffold. It targets iOS 15+ and includes placeholder implementations for authentication, workouts, audio, and payments while keeping integration points ready for Spotify, ElevenLabs, Firebase, and StoreKit 2.
+
+## Project Structure
+
+```
+FITDJ/
+  App/
+  Core/
+  Features/
+  Seeds/
+  Tests/
+```
+
+Seed JSON, placeholder audio/video folders, and stub services allow the app to boot in a simulator without secrets. Replace stub implementations with production-ready services and add the necessary SDKs (Spotify, Firebase, StoreKit 2) to complete functionality.

--- a/Seeds/exercises.json
+++ b/Seeds/exercises.json
@@ -1,0 +1,5 @@
+[
+  {"id": "db_squat", "name": "Dumbbell Squat", "muscles": ["quads", "glutes"], "equipment": ["dumbbells"], "difficulty": "beginner", "video": "db_squat.mp4"},
+  {"id": "air_squat", "name": "Air Squat", "muscles": ["quads", "glutes"], "equipment": ["bodyweight"], "difficulty": "beginner", "video": "air_squat.mp4"},
+  {"id": "pushup", "name": "Push-up", "muscles": ["chest", "triceps"], "equipment": ["bodyweight"], "difficulty": "beginner", "video": "pushup.mp4"}
+]

--- a/Seeds/voice_cues.json
+++ b/Seeds/voice_cues.json
@@ -1,0 +1,4 @@
+[
+  {"id": "cue_warmup_start", "text": "Let's get warm—big energy.", "type": 1, "locale": "en-US", "prebundledAsset": "warmup_start.mp3"},
+  {"id": "cue_push", "text": "Drive through the floor and stay tall!", "type": 3, "locale": "en-US"}
+]

--- a/Seeds/workouts.json
+++ b/Seeds/workouts.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "strength_fb_01",
+    "title": "Full Body Starter",
+    "duration": 30,
+    "level": "beginner",
+    "equipment": ["bodyweight", "dumbbells"],
+    "phases": [
+      {
+        "name": "Warm-up",
+        "blocks": [
+          {"exercise": "jumping_jacks", "duration": 60, "video": "jumping_jacks.mp4", "cues": ["Stay light", "Full arms"]}
+        ]
+      },
+      {
+        "name": "Main",
+        "blocks": [
+          {"branch": "dumbbells", "exercise": "db_squat", "duration": 45, "rest": 15, "cues": ["Heels down", "Chest tall"]},
+          {"branch": "bodyweight", "exercise": "air_squat", "duration": 45, "rest": 15, "cues": ["Knees out", "Neutral spine"]},
+          {"exercise": "pushup", "duration": 45, "rest": 15, "cues": ["Elbows ~45°", "Brace core"]}
+        ]
+      },
+      {
+        "name": "Cool-down",
+        "blocks": [
+          {"exercise": "child_pose", "duration": 60}
+        ]
+      }
+    ],
+    "music": {
+      "playlistAdminId": "ply_strength_fb_01",
+      "bpmTarget": [120, 132],
+      "energy": [0.55, 0.8]
+    }
+  }
+]

--- a/Tests/UITests/OnboardingFlowUITests.swift
+++ b/Tests/UITests/OnboardingFlowUITests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class OnboardingFlowUITests: XCTestCase {
+    func testLaunches() {
+        // Placeholder for UI test automation hooks
+    }
+}

--- a/Tests/UnitTests/TimelineSchedulerTests.swift
+++ b/Tests/UnitTests/TimelineSchedulerTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import FITDJ
+
+final class TimelineSchedulerTests: XCTestCase {
+    func testStartNowSetsTime() async throws {
+        let scheduler = TimelineScheduler()
+        await scheduler.startNow()
+        let now = await scheduler.now()
+        XCTAssertGreaterThanOrEqual(now, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold the SwiftUI-based FITDJ app with an app coordinator, onboarding flow, and workout browsing experience
- define core models, protocols, and stub services for workouts, audio, payments, Spotify, and ElevenLabs integration points
- add brand resources, placeholder media folders, and seed JSON to support a runnable demo configuration

## Testing
- Not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4217f9530832ea58e5191f6b360c8