### PR TITLE
Add FITDJ Xcode project

### DIFF
--- a/App/DI/AppCoordinator.swift
+++ b/App/DI/AppCoordinator.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import Combine
+
+final class AppCoordinator: ObservableObject {
+    private let container: DependencyContainer
+    @Published private var route: AppRoute = .launch
+
+    init(container: DependencyContainer = DependencyContainer()) {
+        self.container = container
+        Task { await bootstrap() }
+    }
+
+    @ViewBuilder
+    func rootView() -> some View {
+        switch route {
+        case .launch:
+            LaunchView()
+                .task { await bootstrap() }
+        case .onboarding:
+            OnboardingCoordinatorView(container: container) {
+                await self.completeOnboarding()
+            }
+        case .home:
+            HomeView(container: container)
+        }
+    }
+
+    @MainActor
+    private func bootstrap() async {
+        let account = try? container.authService.currentUser()
+        route = account != nil ? .home : .onboarding
+    }
+
+    @MainActor
+    private func completeOnboarding() async {
+        route = .home
+    }
+}
+
+enum AppRoute {
+    case launch
+    case onboarding
+    case home
+}

--- a/App/DI/DependencyContainer.swift
+++ b/App/DI/DependencyContainer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+final class DependencyContainer {
+    let workoutRepository: WorkoutRepository
+    let playbackController: PlaybackController
+    let voiceService: VoiceService
+    let musicService: MusicService
+    let authService: AuthService
+    let paymentsService: PaymentsService
+    let analyticsService: AnalyticsService
+
+    init(
+        workoutRepository: WorkoutRepository = WorkoutRepositoryFirestore(),
+        playbackController: PlaybackController = DemoPlaybackController(),
+        voiceService: VoiceService = ElevenLabsVoiceServiceStub(),
+        musicService: MusicService = SpotifyMusicServiceStub(),
+        authService: AuthService = AuthServiceStub(),
+        paymentsService: PaymentsService = PaymentsServiceStub(),
+        analyticsService: AnalyticsService = AnalyticsServiceStub()
+    ) {
+        self.workoutRepository = workoutRepository
+        self.playbackController = playbackController
+        self.voiceService = voiceService
+        self.musicService = musicService
+        self.authService = authService
+        self.paymentsService = paymentsService
+        self.analyticsService = analyticsService
+    }
+}

--- a/App/Extensions/Color+Brand.swift
+++ b/App/Extensions/Color+Brand.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+extension Color {
+    static let fitdjBackground = Color("Background", bundle: .main)
+    static let fitdjAccent = Color("Accent", bundle: .main)
+}

--- a/App/FITDJApp.swift
+++ b/App/FITDJApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct FITDJApp: App {
+    @StateObject private var appCoordinator = AppCoordinator()
+
+    var body: some Scene {
+        WindowGroup {
+            appCoordinator.rootView()
+                .environmentObject(appCoordinator)
+        }
+    }
+}

--- a/App/Resources/Audio/tts_pregenerated/README.md
+++ b/App/Resources/Audio/tts_pregenerated/README.md
@@ -1,0 +1,3 @@
+# Pre-generated Voice Cues
+
+Place common ElevenLabs cues here as MP3 files. These ship with the app bundle for instant playback.

--- a/App/Resources/Colors.xcassets/Accent.colorset/Contents.json
+++ b/App/Resources/Colors.xcassets/Accent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.373",
+          "green" : "0.353",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Colors.xcassets/Background.colorset/Contents.json
+++ b/App/Resources/Colors.xcassets/Background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.318",
+          "green" : "0.129",
+          "red" : "0.102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Colors.xcassets/Contents.json
+++ b/App/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>FITDJ</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string></string>
+                    <key>UISceneStoryboardFile</key>
+                    <string></string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIUserInterfaceStyle</key>
+    <string>Dark</string>
+</dict>
+</plist>

--- a/App/Resources/VideoLoops/README.md
+++ b/App/Resources/VideoLoops/README.md
@@ -1,0 +1,3 @@
+# Video Loops
+
+Store 10–15 second HD MP4 loops for each exercise here. They should be optimized for seamless playback.

--- a/Core/Analytics/AnalyticsServiceStub.swift
+++ b/Core/Analytics/AnalyticsServiceStub.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+final class AnalyticsServiceStub: AnalyticsService {
+    func track(_ event: AnalyticsEvent) {
+        print("Analytics event: \(event.name)")
+    }
+}

--- a/Core/Audio/AudioEngineController.swift
+++ b/Core/Audio/AudioEngineController.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AVFoundation
+import Combine
+
+final class AudioEngineController: ObservableObject {
+    private let engine = AVAudioEngine()
+    private let voicePlayer = AVAudioPlayerNode()
+    private let voiceMixer = AVAudioMixerNode()
+    @Published var coachGain: Float = 0
+
+    init() {
+        engine.attach(voicePlayer)
+        engine.attach(voiceMixer)
+        engine.connect(voicePlayer, to: voiceMixer, format: nil)
+        engine.connect(voiceMixer, to: engine.mainMixerNode, format: nil)
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.allowBluetoothA2DP])
+        try? engine.start()
+    }
+
+    func playVoice(_ fileURL: URL, onStart: @escaping () -> Void, onEnd: @escaping () -> Void) {
+        do {
+            let file = try AVAudioFile(forReading: fileURL)
+            voicePlayer.scheduleFile(file, at: nil) { onEnd() }
+            onStart()
+            voicePlayer.play()
+        } catch {
+            onStart()
+            onEnd()
+        }
+    }
+}

--- a/Core/Audio/CueScheduler.swift
+++ b/Core/Audio/CueScheduler.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class CueScheduler {
+    private let timeline: TimelineScheduler
+    private let voice: VoiceService
+    private let duck: DuckingCoordinator
+
+    init(timeline: TimelineScheduler, voice: VoiceService, duck: DuckingCoordinator) {
+        self.timeline = timeline
+        self.voice = voice
+        self.duck = duck
+    }
+
+    func schedule(cue: VoiceCue, at offset: TimeInterval) {
+        Task {
+            await timeline.schedule(atOffset: offset) { [weak self] in
+                guard let self else { return }
+                Task {
+                    let deadline = Date().addingTimeInterval(0.3)
+                    self.duck.beginDuck(attack: 0.3, gainDB: -12)
+                    await self.voice.speak(cue, deadline: deadline)
+                    self.duck.endDuck(release: 0.3)
+                }
+            }
+        }
+    }
+}

--- a/Core/Audio/DemoPlaybackController.swift
+++ b/Core/Audio/DemoPlaybackController.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+final class DemoPlaybackController: PlaybackController {
+    private var scheduler = TimelineScheduler()
+
+    func start(_ session: WorkoutSession) async throws {
+        scheduler.startNow()
+        // TODO: Bind to real playback engine
+    }
+
+    func pause() {}
+
+    func resume() {}
+
+    func stop() {}
+}

--- a/Core/Audio/DuckingCoordinator.swift
+++ b/Core/Audio/DuckingCoordinator.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol DuckingCoordinator {
+    func beginDuck(attack: TimeInterval, gainDB: Float)
+    func endDuck(release: TimeInterval)
+}
+
+final class SpotifyDuckingCoordinator: DuckingCoordinator {
+    private let musicService: MusicService
+
+    init(musicService: MusicService) {
+        self.musicService = musicService
+    }
+
+    func beginDuck(attack: TimeInterval, gainDB: Float) {
+        musicService.setMusicDuck(level: gainDB, attack: attack, release: 0)
+    }
+
+    func endDuck(release: TimeInterval) {
+        musicService.setMusicDuck(level: 0, attack: 0, release: release)
+    }
+}

--- a/Core/Auth/AuthServiceStub.swift
+++ b/Core/Auth/AuthServiceStub.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class AuthServiceStub: AuthService {
+    private var account: UserAccount?
+
+    func signInWithApple() async throws -> UserAccount {
+        let user = UserAccount(id: UUID().uuidString, name: "Demo Athlete")
+        account = user
+        return user
+    }
+
+    func currentUser() throws -> UserAccount? {
+        account
+    }
+}

--- a/Core/Data/Models.swift
+++ b/Core/Data/Models.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SwiftUI
+
+enum WorkoutLevel: String, Codable, CaseIterable, Identifiable {
+    case beginner, intermediate, advanced
+    var id: String { rawValue }
+}
+
+enum Equipment: String, Codable, CaseIterable, Identifiable {
+    case bodyweight, dumbbells, kettlebell, bands, bench
+    var id: String { rawValue }
+}
+
+struct WorkoutPhase: Codable, Identifiable {
+    struct Block: Codable, Identifiable {
+        let id = UUID()
+        let branch: String?
+        let exercise: String
+        let duration: Int
+        let rest: Int?
+        let video: String?
+        let cues: [String]?
+    }
+
+    let id = UUID()
+    let name: String
+    let blocks: [Block]
+}
+
+struct Workout: Codable, Identifiable {
+    struct MusicBinding: Codable {
+        let playlistAdminId: String
+        let bpmTarget: [Double]
+        let energy: [Double]
+    }
+
+    let id: String
+    let title: String
+    let duration: Int
+    let level: WorkoutLevel
+    let equipment: [Equipment]
+    let phases: [WorkoutPhase]
+    let music: MusicBinding
+}
+
+struct Exercise: Codable, Identifiable {
+    let id: String
+    let name: String
+    let muscles: [String]
+    let equipment: [Equipment]
+    let difficulty: WorkoutLevel
+    let video: String
+}
+
+struct VoiceCue: Codable, Hashable, Identifiable {
+    enum Priority: Int, Codable {
+        case encouragement = 1
+        case countdown = 2
+        case safety = 3
+    }
+
+    let id: String
+    let text: String
+    let type: Priority
+    let locale: String
+    let prebundledAsset: String?
+}
+
+struct PlaylistBinding {
+    let spotifyURI: String
+    let defaultCriteria: TrackCriteria
+}
+
+struct TrackCriteria {
+    let bpm: ClosedRange<Double>
+    let energy: ClosedRange<Double>
+}
+
+struct WorkoutSession {
+    let workout: Workout
+    let startDate: Date
+    let intensity: TrackCriteria
+}
+
+struct UserAccount: Identifiable {
+    let id: String
+    let name: String
+}
+
+struct AnalyticsEvent {
+    let name: String
+    let metadata: [String: String]
+}

--- a/Core/Data/WorkoutRepositoryFirestore.swift
+++ b/Core/Data/WorkoutRepositoryFirestore.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class WorkoutRepositoryFirestore: WorkoutRepository {
+    private let loader: SeedDataLoader
+
+    init(loader: SeedDataLoader = SeedDataLoader()) {
+        self.loader = loader
+    }
+
+    func fetchFeatured() async throws -> [Workout] {
+        return try await loader.loadWorkouts()
+    }
+
+    func get(id: String) async throws -> Workout {
+        let workouts = try await loader.loadWorkouts()
+        guard let workout = workouts.first(where: { $0.id == id }) else {
+            throw NSError(domain: "fitdj", code: 404)
+        }
+        return workout
+    }
+}
+
+final class SeedDataLoader {
+    func loadWorkouts() async throws -> [Workout] {
+        let url = Bundle.main.url(forResource: "workouts", withExtension: "json", subdirectory: "Seeds")
+        let data = try Data(contentsOf: url ?? URL(fileURLWithPath: "Seeds/workouts.json"))
+        let decoder = JSONDecoder()
+        return try decoder.decode([Workout].self, from: data)
+    }
+}

--- a/Core/ElevenLabs/ElevenLabsVoiceServiceStub.swift
+++ b/Core/ElevenLabs/ElevenLabsVoiceServiceStub.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+#if DEBUG
+final class ElevenLabsVoiceServiceStub: VoiceService {
+    func preload(cues: [VoiceCue]) async {}
+    func speak(_ cue: VoiceCue, deadline: Date?) async {
+        // TODO: Integrate ElevenLabs streaming
+    }
+}
+#else
+final class ElevenLabsVoiceServiceStub: VoiceService {
+    func preload(cues: [VoiceCue]) async {}
+    func speak(_ cue: VoiceCue, deadline: Date?) async {}
+}
+#endif

--- a/Core/Network/NetworkClientStub.swift
+++ b/Core/Network/NetworkClientStub.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class NetworkClientStub {
+    func get(_ url: URL) async throws -> Data {
+        // TODO: Replace with real network stack
+        return Data()
+    }
+}

--- a/Core/Payments/PaymentsServiceStub.swift
+++ b/Core/Payments/PaymentsServiceStub.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class PaymentsServiceStub: PaymentsService {
+    private let entitlementContinuation: AsyncStream<Bool>.Continuation
+    let subscriptionEntitlements: AsyncStream<Bool>
+
+    init() {
+        var continuation: AsyncStream<Bool>.Continuation!
+        self.subscriptionEntitlements = AsyncStream { cont in
+            continuation = cont
+        }
+        self.entitlementContinuation = continuation
+        entitlementContinuation.yield(true)
+    }
+
+    func products() async throws -> [Product] {
+        return [
+            Product(id: "fitdj.monthly", title: "FITDJ Monthly", price: "$14.99", freeTrialDays: 7),
+            Product(id: "fitdj.annual", title: "FITDJ Annual", price: "$99.00", freeTrialDays: 7)
+        ]
+    }
+
+    func purchase(_ id: String) async throws {
+        entitlementContinuation.yield(true)
+    }
+}

--- a/Core/Spotify/SpotifyMusicServiceStub.swift
+++ b/Core/Spotify/SpotifyMusicServiceStub.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class SpotifyMusicServiceStub: MusicService {
+    private var authorized = false
+
+    func authorize() async throws {
+        authorized = true
+    }
+
+    func startPlaylist(_ binding: PlaylistBinding) async throws {
+        guard authorized else { throw NSError(domain: "fitdj", code: 401) }
+        // TODO: Bind to Spotify SDK
+    }
+
+    func setMusicDuck(level: Float, attack: TimeInterval, release: TimeInterval) {
+        // TODO: send duck to Spotify SDK
+    }
+
+    func nextTrack(matching: TrackCriteria) async {
+        // TODO: request next track based on criteria
+    }
+}

--- a/Core/Utilities/Configuration.swift
+++ b/Core/Utilities/Configuration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RemoteConfiguration {
+    let elevenLabsKeyEndpoint: URL
+    let spotifyTokenEndpoint: URL
+    let firestoreProjectId: String
+
+    static let stub = RemoteConfiguration(
+        elevenLabsKeyEndpoint: URL(string: "https://api.example.com/fitdj/tts-token")!,
+        spotifyTokenEndpoint: URL(string: "https://api.example.com/fitdj/spotify-token")!,
+        firestoreProjectId: "fitdj-demo"
+    )
+}

--- a/Core/Utilities/Protocols.swift
+++ b/Core/Utilities/Protocols.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+protocol WorkoutRepository {
+    func fetchFeatured() async throws -> [Workout]
+    func get(id: String) async throws -> Workout
+}
+
+protocol PlaybackController {
+    func start(_ session: WorkoutSession) async throws
+    func pause()
+    func resume()
+    func stop()
+}
+
+protocol VoiceService {
+    func preload(cues: [VoiceCue]) async
+    func speak(_ cue: VoiceCue, deadline: Date?) async
+}
+
+protocol MusicService {
+    func authorize() async throws
+    func startPlaylist(_ binding: PlaylistBinding) async throws
+    func setMusicDuck(level: Float, attack: TimeInterval, release: TimeInterval)
+    func nextTrack(matching: TrackCriteria) async
+}
+
+protocol AuthService {
+    func signInWithApple() async throws -> UserAccount
+    func currentUser() throws -> UserAccount?
+}
+
+protocol PaymentsService {
+    func products() async throws -> [Product]
+    func purchase(_ id: String) async throws
+    var subscriptionEntitlements: AsyncStream<Bool> { get }
+}
+
+protocol AnalyticsService {
+    func track(_ event: AnalyticsEvent)
+}
+
+struct Product: Identifiable {
+    let id: String
+    let title: String
+    let price: String
+    let freeTrialDays: Int
+}

--- a/Core/Utilities/TimelineScheduler.swift
+++ b/Core/Utilities/TimelineScheduler.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+actor TimelineScheduler {
+    private var start: DispatchTime?
+
+    func startNow() {
+        start = .now()
+    }
+
+    func now() -> TimeInterval {
+        guard let s = start else { return 0 }
+        let diff = DispatchTime.now().uptimeNanoseconds - s.uptimeNanoseconds
+        return TimeInterval(diff) / 1_000_000_000
+    }
+
+    func schedule(atOffset seconds: TimeInterval, _ action: @escaping () -> Void) async {
+        let deadline = DispatchTime.now() + seconds
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            action()
+        }
+        Task {
+            try? await Task.sleep(until: deadline, clock: .continuous)
+        }
+    }
+}

--- a/FITDJ.xcodeproj/project.pbxproj
+++ b/FITDJ.xcodeproj/project.pbxproj
@@ -1,0 +1,269 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {};
+	objectVersion = 56;
+	objects = {
+
+	/* Begin PBXBuildFile section */
+		F8AC598B3ABA4AD79A5799BC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8B96AB2F54444F93977481; };
+		78F2D09EF4FD4B46B4384670 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7154742374EC4425BD789DF5; };
+		664E55BDAC5A47E8A7B71669 /* Color+Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFA990145E5426D9BCB940D; };
+		97C8AB44AB124CB89FFF81B5 /* FITDJApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9552F46E02D841FEB6BB3C9C; };
+		A4DCECD1B0BC4C278CD8BA8F /* AnalyticsServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F114028668304175A69572D0; };
+		A2AD9D47861C4C6286D723AC /* AudioEngineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495D2587FD974828979A6897; };
+		8B1BE9103D1D49E2B31B01B7 /* CueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29C88B22910468B97E52AC3; };
+		6D0777FE1B6F4DE882E5E46D /* DemoPlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8636C458DEB4010B7633DF1; };
+		9D761D3D71E6498BBE9820FB /* DuckingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123994A83C47437182595E7C; };
+		56D505E1937B4D1BA3B642D6 /* AuthServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528F83362B2E4A759690A419; };
+		EB74456243C54BE7A93F0865 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F21A06D80C4B37AB5C8D18; };
+		BEAA6EF94157486294571787 /* WorkoutRepositoryFirestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BF7411902E46E990922C82; };
+		47BFDC1CBF4146E499F32C99 /* ElevenLabsVoiceServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F48C4A15BD64F20A77A25A5; };
+		55754741FDE644E5AFC29288 /* NetworkClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BEBF41B4024046B0A4D4F4; };
+		CC0CFE19842F4A48AEA2BCFB /* PaymentsServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF2C362296417E83A42F6B; };
+		2B88562D83AE46C9BA8D34AF /* SpotifyMusicServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346A3357FED340AAA5DB9E50; };
+		D65F8B98B4174425852EA4BA /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE8F3BCC2194F84918E3113; };
+		089B615AA15B48EF8869C0AD /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72290B1DEC4574AD5CFEDF; };
+		B83C4A603A53421492A9F192 /* TimelineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E220F870CB4A76BE53A689; };
+		A4846EE273504F50A1A82B08 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB987E1C929F446ABD428A1B; };
+		0B02D515A2514AA393820A9C /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA89098592944D648430B25D; };
+		C4980C7C12E440E5810C75A0 /* OnboardingCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B2F5DD003749E2B64DECA5; };
+		87543AFA9FF04A8F8B81EF22 /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061AF46693754030A24ADFE6; };
+		B56A7772BE464872A93EE7AA /* WorkoutPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3169FD953EA4FD28876F139; };
+		3D3AE1FFF1A64AEAA33E7EFE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570C91EF11314813A4C28111; };
+		145BC73CA89C479C8D2C9961 /* CompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D842F17B1A584F1986175E57; };
+		5A9D4A72EFFA47E79639C1E3 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57AB81884F84603B174790B; };
+		C03BB25133BC4ED691093BB1 /* WorkoutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044BADBE11E54EBDB8D250DA; };
+		FCB68247FD2842D5BF36515D /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3082D96981B6455A94FD14F1; };
+		5A13D6E164264E28B082A65E /* exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 08C76134E2CC4ABCB739713D; };
+		F6FA509CC99D4DBBB5729D1B /* voice_cues.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D6837A029E14292A3D9436D; };
+		09EE218DB5CE4174BD3D7B4E /* workouts.json in Resources */ = {isa = PBXBuildFile; fileRef = 37D06FE8F89D487EB2E4564E; };
+		71F7CCB3FFD44C6C97BEA7CF /* TimelineSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E393567CD9443CAAB3B7270; };
+		D41D6FF1BADB496B866BF000 /* OnboardingFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A8B9180D8C43C38581A9AA; };
+		9BCAD60878894690913F2777 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B7CB539A394A24A604D204; };
+		7998F232C7AA438DA04D94B6 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B7CB539A394A24A604D204; };
+	/* End PBXBuildFile section */
+
+	/* Begin PBXContainerItemProxy section */
+		CC8FF43EB9334E29B0C26B7A /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = 2E04DFAD846845779AC29CBA /* Project object */; proxyType = 1; remoteGlobalIDString = E5BDA61375794A1993E7DB0C; remoteInfo = FITDJ; };
+		73A91B6A60D34298B6AE4238 /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = 2E04DFAD846845779AC29CBA /* Project object */; proxyType = 1; remoteGlobalIDString = E5BDA61375794A1993E7DB0C; remoteInfo = FITDJ; };
+	/* End PBXContainerItemProxy section */
+
+	/* Begin PBXFileReference section */
+		7C8B96AB2F54444F93977481 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DI/AppCoordinator.swift; sourceTree = "<group>"; };
+		7154742374EC4425BD789DF5 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DI/DependencyContainer.swift; sourceTree = "<group>"; };
+		8BFA990145E5426D9BCB940D /* Color+Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/Extensions/Color+Brand.swift; sourceTree = "<group>"; };
+		9552F46E02D841FEB6BB3C9C /* FITDJApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/FITDJApp.swift; sourceTree = "<group>"; };
+		3082D96981B6455A94FD14F1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = App/Resources/Colors.xcassets; sourceTree = "<group>"; };
+		B82D153C03C34AAF83CA67A3 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = App/Resources/Colors.xcassets/Accent.colorset/Contents.json; sourceTree = "<group>"; };
+		F5DFFF52018049EEA5CBCDF7 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = App/Resources/Colors.xcassets/Background.colorset/Contents.json; sourceTree = "<group>"; };
+		8449002996A9489FADCEBDD5 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = App/Resources/Colors.xcassets/Contents.json; sourceTree = "<group>"; };
+		343E09B0A58E4F00B4941601 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = App/Resources/Info.plist; sourceTree = "<group>"; };
+		F114028668304175A69572D0 /* AnalyticsServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Analytics/AnalyticsServiceStub.swift; sourceTree = "<group>"; };
+		495D2587FD974828979A6897 /* AudioEngineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Audio/AudioEngineController.swift; sourceTree = "<group>"; };
+		F29C88B22910468B97E52AC3 /* CueScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Audio/CueScheduler.swift; sourceTree = "<group>"; };
+		B8636C458DEB4010B7633DF1 /* DemoPlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Audio/DemoPlaybackController.swift; sourceTree = "<group>"; };
+		123994A83C47437182595E7C /* DuckingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Audio/DuckingCoordinator.swift; sourceTree = "<group>"; };
+		528F83362B2E4A759690A419 /* AuthServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Auth/AuthServiceStub.swift; sourceTree = "<group>"; };
+		B1F21A06D80C4B37AB5C8D18 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Data/Models.swift; sourceTree = "<group>"; };
+		52BF7411902E46E990922C82 /* WorkoutRepositoryFirestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Data/WorkoutRepositoryFirestore.swift; sourceTree = "<group>"; };
+		8F48C4A15BD64F20A77A25A5 /* ElevenLabsVoiceServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/ElevenLabs/ElevenLabsVoiceServiceStub.swift; sourceTree = "<group>"; };
+		77BEBF41B4024046B0A4D4F4 /* NetworkClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Network/NetworkClientStub.swift; sourceTree = "<group>"; };
+		22CF2C362296417E83A42F6B /* PaymentsServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Payments/PaymentsServiceStub.swift; sourceTree = "<group>"; };
+		346A3357FED340AAA5DB9E50 /* SpotifyMusicServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Spotify/SpotifyMusicServiceStub.swift; sourceTree = "<group>"; };
+		7FE8F3BCC2194F84918E3113 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Utilities/Configuration.swift; sourceTree = "<group>"; };
+		9D72290B1DEC4574AD5CFEDF /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Utilities/Protocols.swift; sourceTree = "<group>"; };
+		E0E220F870CB4A76BE53A689 /* TimelineScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Utilities/TimelineScheduler.swift; sourceTree = "<group>"; };
+		AB987E1C929F446ABD428A1B /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Library/LibraryView.swift; sourceTree = "<group>"; };
+		CA89098592944D648430B25D /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Onboarding/LaunchView.swift; sourceTree = "<group>"; };
+		D4B2F5DD003749E2B64DECA5 /* OnboardingCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Onboarding/OnboardingCoordinatorView.swift; sourceTree = "<group>"; };
+		061AF46693754030A24ADFE6 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Paywall/PaywallView.swift; sourceTree = "<group>"; };
+		F3169FD953EA4FD28876F139 /* WorkoutPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Player/WorkoutPlayerView.swift; sourceTree = "<group>"; };
+		570C91EF11314813A4C28111 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Settings/SettingsView.swift; sourceTree = "<group>"; };
+		D842F17B1A584F1986175E57 /* CompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Workouts/CompletionView.swift; sourceTree = "<group>"; };
+		D57AB81884F84603B174790B /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Workouts/HomeView.swift; sourceTree = "<group>"; };
+		044BADBE11E54EBDB8D250DA /* WorkoutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features/Workouts/WorkoutDetailView.swift; sourceTree = "<group>"; };
+		08C76134E2CC4ABCB739713D /* exercises.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Seeds/exercises.json; sourceTree = "<group>"; };
+		2D6837A029E14292A3D9436D /* voice_cues.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Seeds/voice_cues.json; sourceTree = "<group>"; };
+		37D06FE8F89D487EB2E4564E /* workouts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Seeds/workouts.json; sourceTree = "<group>"; };
+		75A8B9180D8C43C38581A9AA /* OnboardingFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests/UITests/OnboardingFlowUITests.swift; sourceTree = "<group>"; };
+		2E393567CD9443CAAB3B7270 /* TimelineSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests/UnitTests/TimelineSchedulerTests.swift; sourceTree = "<group>"; };
+		487421D75A8C4F4DA7F06653 /* FITDJ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FITDJ.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		36A5739E868447299D3A6105 /* FITDJTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FITDJTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F507E371C8B648EBB07DA4FB /* FITDJUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FITDJUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		39B7CB539A394A24A604D204 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = System/Library/Frameworks/XCTest.framework; sourceTree = SDKROOT; };
+	/* End PBXFileReference section */
+
+	/* Begin PBXFrameworksBuildPhase section */
+		7E57485A29B4456AA7E4C6D6 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		08139377388F478FBA07B5EA /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (9BCAD60878894690913F2777); runOnlyForDeploymentPostprocessing = 0; };
+		AACA2E65E110446FB350DE25 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (7998F232C7AA438DA04D94B6); runOnlyForDeploymentPostprocessing = 0; };
+	/* End PBXFrameworksBuildPhase section */
+
+	/* Begin PBXGroup section */
+		E75712C0E5F649D0B3CD2ACB /* ROOT */ = {isa = PBXGroup; children = (212221B5EA074FE080104429, E80A4F3B230A4677A3136498, 26ED237B79224EF8BFE28AB7, 559EE6693FD74163A5D4326A, D9C3112B729D4AF0B1E76B90, 39AAE63F91D94F81B924E817, 9D0C2E99ED7345279007567A); sourceTree = "<group>"; };
+		212221B5EA074FE080104429 /* App */ = {isa = PBXGroup; children = (5A1F67DA7E704042BF37DF30, DF1E398E99AC4962BCE1CB07, AAD912A1D9784B47B82F011E, 9552F46E02D841FEB6BB3C9C); sourceTree = "<group>"; name = App; path = App; };
+		5A1F67DA7E704042BF37DF30 /* DI */ = {isa = PBXGroup; children = (7C8B96AB2F54444F93977481, 7154742374EC4425BD789DF5); sourceTree = "<group>"; name = DI; path = App/DI; };
+		DF1E398E99AC4962BCE1CB07 /* Extensions */ = {isa = PBXGroup; children = (8BFA990145E5426D9BCB940D); sourceTree = "<group>"; name = Extensions; path = App/Extensions; };
+		AAD912A1D9784B47B82F011E /* Resources */ = {isa = PBXGroup; children = (BF550027AA6143FFAC7FED7E, 3082D96981B6455A94FD14F1, 343E09B0A58E4F00B4941601); sourceTree = "<group>"; name = Resources; path = App/Resources; };
+		BF550027AA6143FFAC7FED7E /* Colors.xcassets */ = {isa = PBXGroup; children = (E83574D32E6145ADAF2FBB3D, 1D9DEA59C60045309EA2856A, 8449002996A9489FADCEBDD5); sourceTree = "<group>"; name = Colors.xcassets; path = App/Resources/Colors.xcassets; };
+		E83574D32E6145ADAF2FBB3D /* Accent.colorset */ = {isa = PBXGroup; children = (B82D153C03C34AAF83CA67A3); sourceTree = "<group>"; name = Accent.colorset; path = App/Resources/Colors.xcassets/Accent.colorset; };
+		1D9DEA59C60045309EA2856A /* Background.colorset */ = {isa = PBXGroup; children = (F5DFFF52018049EEA5CBCDF7); sourceTree = "<group>"; name = Background.colorset; path = App/Resources/Colors.xcassets/Background.colorset; };
+		E80A4F3B230A4677A3136498 /* Core */ = {isa = PBXGroup; children = (8EA985C12AE849B8B7B32E8C, 2860B35BB6AB427B9F5A9E31, B307E0B72CF54EFFB35409DC, CF52D23DD1934709BFF02284, D8AA9DF8F0364BF0BB2C8850, F7A58091491F41DC9D19BAF4, 50A8B929137E4E018E8DB43E, D6599F7F1E51403EB0A17AD4, 3D6A58DDA5F740CEA5B6BB6A); sourceTree = "<group>"; name = Core; path = Core; };
+		8EA985C12AE849B8B7B32E8C /* Analytics */ = {isa = PBXGroup; children = (F114028668304175A69572D0); sourceTree = "<group>"; name = Analytics; path = Core/Analytics; };
+		2860B35BB6AB427B9F5A9E31 /* Audio */ = {isa = PBXGroup; children = (495D2587FD974828979A6897, F29C88B22910468B97E52AC3, B8636C458DEB4010B7633DF1, 123994A83C47437182595E7C); sourceTree = "<group>"; name = Audio; path = Core/Audio; };
+		B307E0B72CF54EFFB35409DC /* Auth */ = {isa = PBXGroup; children = (528F83362B2E4A759690A419); sourceTree = "<group>"; name = Auth; path = Core/Auth; };
+		CF52D23DD1934709BFF02284 /* Data */ = {isa = PBXGroup; children = (B1F21A06D80C4B37AB5C8D18, 52BF7411902E46E990922C82); sourceTree = "<group>"; name = Data; path = Core/Data; };
+		D8AA9DF8F0364BF0BB2C8850 /* ElevenLabs */ = {isa = PBXGroup; children = (8F48C4A15BD64F20A77A25A5); sourceTree = "<group>"; name = ElevenLabs; path = Core/ElevenLabs; };
+		F7A58091491F41DC9D19BAF4 /* Network */ = {isa = PBXGroup; children = (77BEBF41B4024046B0A4D4F4); sourceTree = "<group>"; name = Network; path = Core/Network; };
+		50A8B929137E4E018E8DB43E /* Payments */ = {isa = PBXGroup; children = (22CF2C362296417E83A42F6B); sourceTree = "<group>"; name = Payments; path = Core/Payments; };
+		D6599F7F1E51403EB0A17AD4 /* Spotify */ = {isa = PBXGroup; children = (346A3357FED340AAA5DB9E50); sourceTree = "<group>"; name = Spotify; path = Core/Spotify; };
+		3D6A58DDA5F740CEA5B6BB6A /* Utilities */ = {isa = PBXGroup; children = (7FE8F3BCC2194F84918E3113, 9D72290B1DEC4574AD5CFEDF, E0E220F870CB4A76BE53A689); sourceTree = "<group>"; name = Utilities; path = Core/Utilities; };
+		26ED237B79224EF8BFE28AB7 /* Features */ = {isa = PBXGroup; children = (B786E549D68F4655B438DB9F, F93F0C02E57B432D8F55E241, 9AADA17EB50B4784AD1AA293, C3AEECA12CD84EDA954F1C4A, 344D11D9F07E4F73BD9D9E6B, 0D78A3B38C2247859C92E7DC); sourceTree = "<group>"; name = Features; path = Features; };
+		B786E549D68F4655B438DB9F /* Library */ = {isa = PBXGroup; children = (AB987E1C929F446ABD428A1B); sourceTree = "<group>"; name = Library; path = Features/Library; };
+		F93F0C02E57B432D8F55E241 /* Onboarding */ = {isa = PBXGroup; children = (CA89098592944D648430B25D, D4B2F5DD003749E2B64DECA5); sourceTree = "<group>"; name = Onboarding; path = Features/Onboarding; };
+		9AADA17EB50B4784AD1AA293 /* Paywall */ = {isa = PBXGroup; children = (061AF46693754030A24ADFE6); sourceTree = "<group>"; name = Paywall; path = Features/Paywall; };
+		C3AEECA12CD84EDA954F1C4A /* Player */ = {isa = PBXGroup; children = (F3169FD953EA4FD28876F139); sourceTree = "<group>"; name = Player; path = Features/Player; };
+		344D11D9F07E4F73BD9D9E6B /* Settings */ = {isa = PBXGroup; children = (570C91EF11314813A4C28111); sourceTree = "<group>"; name = Settings; path = Features/Settings; };
+		0D78A3B38C2247859C92E7DC /* Workouts */ = {isa = PBXGroup; children = (D842F17B1A584F1986175E57, D57AB81884F84603B174790B, 044BADBE11E54EBDB8D250DA); sourceTree = "<group>"; name = Workouts; path = Features/Workouts; };
+		559EE6693FD74163A5D4326A /* Seeds */ = {isa = PBXGroup; children = (08C76134E2CC4ABCB739713D, 2D6837A029E14292A3D9436D, 37D06FE8F89D487EB2E4564E); sourceTree = "<group>"; name = Seeds; path = Seeds; };
+		D9C3112B729D4AF0B1E76B90 /* Tests */ = {isa = PBXGroup; children = (5CFB6B70D1B34C0988004154, 5744B1C0ADE24CEAB20F2C23); sourceTree = "<group>"; name = Tests; path = Tests; };
+		5CFB6B70D1B34C0988004154 /* UITests */ = {isa = PBXGroup; children = (75A8B9180D8C43C38581A9AA); sourceTree = "<group>"; name = UITests; path = Tests/UITests; };
+		5744B1C0ADE24CEAB20F2C23 /* UnitTests */ = {isa = PBXGroup; children = (2E393567CD9443CAAB3B7270); sourceTree = "<group>"; name = UnitTests; path = Tests/UnitTests; };
+		9D0C2E99ED7345279007567A /* Products */ = {isa = PBXGroup; children = (487421D75A8C4F4DA7F06653, 36A5739E868447299D3A6105, F507E371C8B648EBB07DA4FB); name = Products; sourceTree = "<group>"; };
+		39AAE63F91D94F81B924E817 /* Frameworks */ = {isa = PBXGroup; children = (39B7CB539A394A24A604D204); name = Frameworks; sourceTree = "<group>"; };
+	/* End PBXGroup section */
+
+	/* Begin PBXNativeTarget section */
+		E5BDA61375794A1993E7DB0C /* FITDJ */ = {isa = PBXNativeTarget; buildConfigurationList = 01CA5E469B244C98ABD94531 /* Build configuration list for PBXNativeTarget "FITDJ" */; buildPhases = (B293E1B9A93B4310B57440E4, 7E57485A29B4456AA7E4C6D6, B40ABEB7DE0D4D4DA4CE630B); buildRules = (); dependencies = (); name = FITDJ; productName = FITDJ; productReference = 487421D75A8C4F4DA7F06653 /* FITDJ.app */; productType = "com.apple.product-type.application"; };
+		0ADBE0CD1BEA4CF6B2555ABC /* FITDJTests */ = {isa = PBXNativeTarget; buildConfigurationList = C14627A463624D7F8D67D705 /* Build configuration list for PBXNativeTarget "FITDJTests" */; buildPhases = (41B90A0732D94B17B138706D, 08139377388F478FBA07B5EA); buildRules = (); dependencies = (ED2315E1E7C14FD0AAF40A57); name = FITDJTests; productName = FITDJTests; productReference = 36A5739E868447299D3A6105 /* FITDJTests.xctest */; productType = "com.apple.product-type.bundle.unit-test"; };
+		7D09145C02624244A4E1A0A9 /* FITDJUITests */ = {isa = PBXNativeTarget; buildConfigurationList = 33E6B02BB19A463995E8986F /* Build configuration list for PBXNativeTarget "FITDJUITests" */; buildPhases = (320DBFCC00C14A7697E2ED78, AACA2E65E110446FB350DE25); buildRules = (); dependencies = (E453DD683B584D1E9380BD60); name = FITDJUITests; productName = FITDJUITests; productReference = F507E371C8B648EBB07DA4FB /* FITDJUITests.xctest */; productType = "com.apple.product-type.bundle.ui-testing"; };
+	/* End PBXNativeTarget section */
+
+	/* Begin PBXProject section */
+		2E04DFAD846845779AC29CBA /* Project object */ = {isa = PBXProject; buildConfigurationList = 340CB1EF588148A5A72F6753 /* Build configuration list for PBXProject "FITDJ" */; compatibilityVersion = "Xcode 14.0"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (en, Base); mainGroup = E75712C0E5F649D0B3CD2ACB; productRefGroup = 9D0C2E99ED7345279007567A; projectDirPath = ""; projectRoot = ""; targets = (E5BDA61375794A1993E7DB0C, 0ADBE0CD1BEA4CF6B2555ABC, 7D09145C02624244A4E1A0A9); };
+	/* End PBXProject section */
+
+	/* Begin PBXResourcesBuildPhase section */
+			B40ABEB7DE0D4D4DA4CE630B /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (FCB68247FD2842D5BF36515D, 5A13D6E164264E28B082A65E, F6FA509CC99D4DBBB5729D1B, 09EE218DB5CE4174BD3D7B4E); runOnlyForDeploymentPostprocessing = 0; };
+	/* End PBXResourcesBuildPhase section */
+
+	/* Begin PBXSourcesBuildPhase section */
+		B293E1B9A93B4310B57440E4 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (F8AC598B3ABA4AD79A5799BC, 78F2D09EF4FD4B46B4384670, 664E55BDAC5A47E8A7B71669, 97C8AB44AB124CB89FFF81B5, A4DCECD1B0BC4C278CD8BA8F, A2AD9D47861C4C6286D723AC, 8B1BE9103D1D49E2B31B01B7, 6D0777FE1B6F4DE882E5E46D, 9D761D3D71E6498BBE9820FB, 56D505E1937B4D1BA3B642D6, EB74456243C54BE7A93F0865, BEAA6EF94157486294571787, 47BFDC1CBF4146E499F32C99, 55754741FDE644E5AFC29288, CC0CFE19842F4A48AEA2BCFB, 2B88562D83AE46C9BA8D34AF, D65F8B98B4174425852EA4BA, 089B615AA15B48EF8869C0AD, B83C4A603A53421492A9F192, A4846EE273504F50A1A82B08, 0B02D515A2514AA393820A9C, C4980C7C12E440E5810C75A0, 87543AFA9FF04A8F8B81EF22, B56A7772BE464872A93EE7AA, 3D3AE1FFF1A64AEAA33E7EFE, 145BC73CA89C479C8D2C9961, 5A9D4A72EFFA47E79639C1E3, C03BB25133BC4ED691093BB1); runOnlyForDeploymentPostprocessing = 0; };
+		41B90A0732D94B17B138706D /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (71F7CCB3FFD44C6C97BEA7CF); runOnlyForDeploymentPostprocessing = 0; };
+		320DBFCC00C14A7697E2ED78 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (D41D6FF1BADB496B866BF000); runOnlyForDeploymentPostprocessing = 0; };
+	/* End PBXSourcesBuildPhase section */
+
+	/* Begin PBXTargetDependency section */
+		ED2315E1E7C14FD0AAF40A57 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = E5BDA61375794A1993E7DB0C /* FITDJ */; targetProxy = CC8FF43EB9334E29B0C26B7A /* PBXContainerItemProxy */; };
+		E453DD683B584D1E9380BD60 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = E5BDA61375794A1993E7DB0C /* FITDJ */; targetProxy = 73A91B6A60D34298B6AE4238 /* PBXContainerItemProxy */; };
+	/* End PBXTargetDependency section */
+
+	/* Begin XCBuildConfiguration section */
+		06EB3EF47D82427DB021AC4E /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				SWIFT_VERSION = 5.0;
+			}; name = Debug; };
+		7B66D258630A47639AF0F4FC /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				SWIFT_VERSION = 5.0;
+			}; name = Release; };
+		A9D7A90A0B914906B48D8BBE /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = App/Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.app;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1,2;
+			}; name = Debug; };
+		B1C41897ABC6406FAE19152E /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = App/Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.app;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = -O;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1,2;
+			}; name = Release; };
+		80B46614B46A4101AE34BF46 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.tests;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FITDJ.app/FITDJ";
+			}; name = Debug; };
+		AF73D2F63ED447E59D1690A5 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.tests;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FITDJ.app/FITDJ";
+			}; name = Release; };
+		1A4CF28A7D1A4FBFABCFB183 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.uitests;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1,2;
+			}; name = Debug; };
+		80D0A01A3857453B82946F4B /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fitdj.uitests;
+				PRODUCT_NAME = $(TARGET_NAME);
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1,2;
+			}; name = Release; };
+	/* End XCBuildConfiguration section */
+
+	/* Begin XCConfigurationList section */
+		340CB1EF588148A5A72F6753 /* Build configuration list for PBXProject "FITDJ" */ = {isa = XCConfigurationList; buildConfigurations = (06EB3EF47D82427DB021AC4E, 7B66D258630A47639AF0F4FC); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		01CA5E469B244C98ABD94531 /* Build configuration list for PBXNativeTarget "FITDJ" */ = {isa = XCConfigurationList; buildConfigurations = (A9D7A90A0B914906B48D8BBE, B1C41897ABC6406FAE19152E); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		C14627A463624D7F8D67D705 /* Build configuration list for PBXNativeTarget "FITDJTests" */ = {isa = XCConfigurationList; buildConfigurations = (80B46614B46A4101AE34BF46, AF73D2F63ED447E59D1690A5); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		33E6B02BB19A463995E8986F /* Build configuration list for PBXNativeTarget "FITDJUITests" */ = {isa = XCConfigurationList; buildConfigurations = (1A4CF28A7D1A4FBFABCFB183, 80D0A01A3857453B82946F4B); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+	/* End XCConfigurationList section */
+
+	};
+	rootObject = 2E04DFAD846845779AC29CBA /* Project object */;
+}

--- a/Features/Library/LibraryView.swift
+++ b/Features/Library/LibraryView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct LibraryView: View {
+    let workouts: [Workout]
+
+    var body: some View {
+        List(workouts) { workout in
+            Text(workout.title)
+                .foregroundColor(.white)
+        }
+        .listStyle(.plain)
+        .background(Color.black)
+        .navigationTitle("Library")
+    }
+}

--- a/Features/Onboarding/LaunchView.swift
+++ b/Features/Onboarding/LaunchView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct LaunchView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Preparing FITDJ…")
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Onboarding/OnboardingCoordinatorView.swift
+++ b/Features/Onboarding/OnboardingCoordinatorView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct OnboardingCoordinatorView: View {
+    let container: DependencyContainer
+    let completion: () async -> Void
+    @State private var step: Int = 0
+    @State private var goal: String = "Strength"
+    @State private var equipment: Set<Equipment> = []
+    @State private var musicPreference: Double = 0.5
+
+    var body: some View {
+        VStack {
+            TabView(selection: $step) {
+                GoalStep(goal: $goal)
+                    .tag(0)
+                EquipmentStep(selection: $equipment)
+                    .tag(1)
+                MusicStep(level: $musicPreference)
+                    .tag(2)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .background(Color.fitdjBackground)
+
+            Button(action: next) {
+                Text(step == 2 ? "Continue" : "Next")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.fitdjAccent)
+                    .foregroundColor(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .padding()
+        }
+        .background(Color.black.ignoresSafeArea())
+        .animation(.easeInOut, value: step)
+        .task {
+            await container.musicService.authorize()
+        }
+    }
+
+    private func next() {
+        if step < 2 {
+            step += 1
+        } else {
+            Task { await completion() }
+        }
+    }
+}
+
+private struct GoalStep: View {
+    @Binding var goal: String
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("What brings you to FITDJ?")
+                .font(.title2.bold())
+            Picker("Goal", selection: $goal) {
+                Text("Strength").tag("Strength")
+                Text("Endurance").tag("Endurance")
+                Text("Mobility").tag("Mobility")
+            }
+            .pickerStyle(.segmented)
+        }
+        .padding()
+    }
+}
+
+private struct EquipmentStep: View {
+    @Binding var selection: Set<Equipment>
+    let options: [Equipment] = Equipment.allCases
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("What equipment do you have?")
+                .font(.title2.bold())
+            ForEach(options) { item in
+                Toggle(item.rawValue.capitalized, isOn: Binding(
+                    get: { selection.contains(item) },
+                    set: { isOn in
+                        if isOn { selection.insert(item) } else { selection.remove(item) }
+                    }
+                ))
+                .toggleStyle(.switch)
+            }
+        }
+        .padding()
+    }
+}
+
+private struct MusicStep: View {
+    @Binding var level: Double
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Text("Coach or Music?")
+                .font(.title2.bold())
+            Slider(value: $level, in: 0...1)
+            Text("Balance: \(Int(level * 100))% coach")
+        }
+        .padding()
+    }
+}

--- a/Features/Paywall/PaywallView.swift
+++ b/Features/Paywall/PaywallView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PaywallView: View {
+    let products: [Product]
+    let subscribe: (Product) -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Unlock FITDJ")
+                .font(.largeTitle.bold())
+            Text("Unlimited strength training with dynamic coaching and Spotify integration.")
+                .multilineTextAlignment(.center)
+            ForEach(products) { product in
+                Button(action: { subscribe(product) }) {
+                    VStack(alignment: .leading) {
+                        Text(product.title)
+                            .font(.headline)
+                        Text("\(product.price) · \(product.freeTrialDays)-day free trial")
+                            .font(.subheadline)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.fitdjAccent)
+                    .foregroundColor(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }
+            Text("$14.99/month or $99/year after free trial. Cancel anytime.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Player/WorkoutPlayerView.swift
+++ b/Features/Player/WorkoutPlayerView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct WorkoutPlayerView: View {
+    let workout: Workout
+    let container: DependencyContainer
+    @State private var timeRemaining: Int = 0
+    @State private var isPaused = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(workout.title)
+                .font(.title.bold())
+            Text("Time Remaining: \(timeRemaining)s")
+                .font(.largeTitle.monospacedDigit())
+            Slider(value: .constant(0.5))
+            HStack(spacing: 16) {
+                Button(isPaused ? "Resume" : "Pause") { togglePause() }
+                Button("Skip") {}
+                Button("Easier") {}
+                Button("Harder") {}
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.fitdjAccent)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+        .onAppear {
+            timeRemaining = workout.duration * 60
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+
+    private func togglePause() {
+        isPaused.toggle()
+    }
+}

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct SettingsView: View {
+    let container: DependencyContainer
+    @State private var captionsEnabled = true
+    @State private var products: [Product] = []
+
+    var body: some View {
+        Form {
+            Section("Audio") {
+                Toggle("Captions", isOn: $captionsEnabled)
+                Button("Connect Spotify") {
+                    Task { try? await container.musicService.authorize() }
+                }
+            }
+            Section("Account") {
+                Button("Sign in with Apple") {
+                    Task { _ = try? await container.authService.signInWithApple() }
+                }
+            }
+            Section("Subscription") {
+                if products.isEmpty {
+                    Text("Loading products…")
+                } else {
+                    ForEach(products) { product in
+                        Button("Subscribe to \(product.title) – \(product.price)") {
+                            Task { try? await container.paymentsService.purchase(product.id) }
+                        }
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.black)
+        .foregroundColor(.white)
+        .navigationTitle("Settings")
+        .tint(Color.fitdjAccent)
+        .task { await loadProducts() }
+    }
+
+    private func loadProducts() async {
+        products = (try? await container.paymentsService.products()) ?? []
+    }
+}

--- a/Features/Workouts/CompletionView.swift
+++ b/Features/Workouts/CompletionView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CompletionView: View {
+    let workout: Workout
+    let duration: TimeInterval
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Workout Complete!")
+                .font(.largeTitle.bold())
+            Text("You crushed \(workout.title) in \(Int(duration / 60)) minutes.")
+            Button("Share") {}
+                .buttonStyle(.borderedProminent)
+                .tint(Color.fitdjAccent)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
+    }
+}

--- a/Features/Workouts/HomeView.swift
+++ b/Features/Workouts/HomeView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct HomeView: View {
+    let container: DependencyContainer
+    @State private var workouts: [Workout] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    List(workouts) { workout in
+                        NavigationLink(destination: WorkoutDetailView(workout: workout, container: container)) {
+                            WorkoutRow(workout: workout)
+                        }
+                        .listRowBackground(Color.black)
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Featured")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: SettingsView(container: container)) {
+                        Image(systemName: "gear")
+                    }
+                }
+            }
+        }
+        .accentColor(Color.fitdjAccent)
+        .task { await loadWorkouts() }
+    }
+
+    private func loadWorkouts() async {
+        do {
+            workouts = try await container.workoutRepository.fetchFeatured()
+        } catch {
+            workouts = []
+        }
+        isLoading = false
+    }
+}
+
+private struct WorkoutRow: View {
+    let workout: Workout
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(workout.title)
+                .font(.headline)
+                .foregroundColor(.white)
+            Text("\(workout.duration) min · \(workout.level.rawValue.capitalized)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/Features/Workouts/WorkoutDetailView.swift
+++ b/Features/Workouts/WorkoutDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct WorkoutDetailView: View {
+    let workout: Workout
+    let container: DependencyContainer
+    @State private var showingPlayer = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(workout.title)
+                    .font(.largeTitle.bold())
+                Text("Duration: \(workout.duration) minutes")
+                Text("Equipment: \(workout.equipment.map { $0.rawValue.capitalized }.joined(separator: ", "))")
+                Text("Level: \(workout.level.rawValue.capitalized)")
+                Divider()
+                ForEach(workout.phases) { phase in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(phase.name)
+                            .font(.headline)
+                        ForEach(phase.blocks) { block in
+                            Text(block.exercise.replacingOccurrences(of: "_", with: " "))
+                                .font(.subheadline)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                }
+            }
+            .padding()
+            .foregroundColor(.white)
+        }
+        .background(Color.black.ignoresSafeArea())
+        .toolbar {
+            Button("Start") { showingPlayer = true }
+        }
+        .sheet(isPresented: $showingPlayer) {
+            WorkoutPlayerView(workout: workout, container: container)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# FITDJ iOS App Skeleton
+
+This repository contains the SwiftUI-based FITDJ application scaffold. It targets iOS 15+ and includes placeholder implementations for authentication, workouts, audio, and payments while keeping integration points ready for Spotify, ElevenLabs, Firebase, and StoreKit 2.
+
+## Project Structure
+
+```
+FITDJ/
+  App/
+  Core/
+  Features/
+  Seeds/
+  Tests/
+```
+
+## Seed Data & Assets
+
+Seed JSON, placeholder audio/video folders, and stub services allow the app to boot in a simulator without secrets. Replace stub implementations with production-ready services and add the necessary SDKs (Spotify, Firebase, StoreKit 2) to complete functionality. See [`Seeds/README.md`](Seeds/README.md) for a short reminder when populating real data.
+
+## Running in Xcode
+
+1. Open the project in Xcode 15 or newer (use `File > Open...` and select `FITDJ.xcodeproj`).
+2. Ensure the active scheme is **FITDJ** and a simulator (iPhone 15 Pro or similar) is selected.
+3. Press **Cmd+R** to build and launch the app. The stubbed services will let the demo run without real backend credentials.
+4. When you are ready for production integrations, add the Spotify, Firebase, and StoreKit 2 SDKs via Swift Package Manager or XCFrameworks, swap the stub services for the real implementations, and configure any required capabilities (Background Modes, Sign in with Apple, etc.).
+
+## Requirements
+
+- Xcode 15+
+- iOS 15.0+ deployment target
+- Swift 5.9 toolchain
+
+## Testing
+
+Unit and UI test targets are included under `Tests/`. You can run them from Xcode with **Product > Test** once you flesh out the implementations.

--- a/Seeds/README.md
+++ b/Seeds/README.md
@@ -1,0 +1,1 @@
+Seed JSON, placeholder audio/video folders, and stub services allow the app to boot in a simulator without secrets. Replace stub implementations with production-ready services and add the necessary SDKs (Spotify, Firebase, StoreKit 2) to complete functionality.

--- a/Seeds/exercises.json
+++ b/Seeds/exercises.json
@@ -1,0 +1,5 @@
+[
+  {"id": "db_squat", "name": "Dumbbell Squat", "muscles": ["quads", "glutes"], "equipment": ["dumbbells"], "difficulty": "beginner", "video": "db_squat.mp4"},
+  {"id": "air_squat", "name": "Air Squat", "muscles": ["quads", "glutes"], "equipment": ["bodyweight"], "difficulty": "beginner", "video": "air_squat.mp4"},
+  {"id": "pushup", "name": "Push-up", "muscles": ["chest", "triceps"], "equipment": ["bodyweight"], "difficulty": "beginner", "video": "pushup.mp4"}
+]

--- a/Seeds/voice_cues.json
+++ b/Seeds/voice_cues.json
@@ -1,0 +1,4 @@
+[
+  {"id": "cue_warmup_start", "text": "Let's get warm—big energy.", "type": 1, "locale": "en-US", "prebundledAsset": "warmup_start.mp3"},
+  {"id": "cue_push", "text": "Drive through the floor and stay tall!", "type": 3, "locale": "en-US"}
+]

--- a/Seeds/workouts.json
+++ b/Seeds/workouts.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "strength_fb_01",
+    "title": "Full Body Starter",
+    "duration": 30,
+    "level": "beginner",
+    "equipment": ["bodyweight", "dumbbells"],
+    "phases": [
+      {
+        "name": "Warm-up",
+        "blocks": [
+          {"exercise": "jumping_jacks", "duration": 60, "video": "jumping_jacks.mp4", "cues": ["Stay light", "Full arms"]}
+        ]
+      },
+      {
+        "name": "Main",
+        "blocks": [
+          {"branch": "dumbbells", "exercise": "db_squat", "duration": 45, "rest": 15, "cues": ["Heels down", "Chest tall"]},
+          {"branch": "bodyweight", "exercise": "air_squat", "duration": 45, "rest": 15, "cues": ["Knees out", "Neutral spine"]},
+          {"exercise": "pushup", "duration": 45, "rest": 15, "cues": ["Elbows ~45°", "Brace core"]}
+        ]
+      },
+      {
+        "name": "Cool-down",
+        "blocks": [
+          {"exercise": "child_pose", "duration": 60}
+        ]
+      }
+    ],
+    "music": {
+      "playlistAdminId": "ply_strength_fb_01",
+      "bpmTarget": [120, 132],
+      "energy": [0.55, 0.8]
+    }
+  }
+]

--- a/Tests/UITests/OnboardingFlowUITests.swift
+++ b/Tests/UITests/OnboardingFlowUITests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class OnboardingFlowUITests: XCTestCase {
+    func testLaunches() {
+        // Placeholder for UI test automation hooks
+    }
+}

--- a/Tests/UnitTests/TimelineSchedulerTests.swift
+++ b/Tests/UnitTests/TimelineSchedulerTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import FITDJ
+
+final class TimelineSchedulerTests: XCTestCase {
+    func testStartNowSetsTime() async throws {
+        let scheduler = TimelineScheduler()
+        await scheduler.startNow()
+        let now = await scheduler.now()
+        XCTAssertGreaterThanOrEqual(now, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- add a checked-in `FITDJ.xcodeproj` with app, unit test, and UI test targets wired to the existing Swift sources and resources
- add an Info.plist configured for the SwiftUI app bundle and a dark appearance launch policy
- update the README run instructions to point at the committed Xcode project

## Testing
- Not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4217f9530832ea58e5191f6b360c8